### PR TITLE
Update documentation for Align Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ All props without description are just true or false values and take no argument
 * contentBaseline
 * contentStretch
 * contentAround
-* contentStretch
 
 #### Justify Content
 


### PR DESCRIPTION
Remove duplicated `contentStretch` prop in the Align Content documentation.