### PR TITLE
Upgrade styled-is for ES5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,12 @@
     "prepublish": "NODE_ENV=production bup"
   },
   "dependencies": {
-    "styled-is": "1.1.2"
+    "styled-is": "1.1.5"
   },
   "peerDependencies": {
     "styled-components": "^3.1.4"
   },
   "devDependencies": {
-    "styled-components": "3.1.4",
     "babel-plugin-styled-components": "^1.5.0",
     "babel-preset-env": "^1.6.1",
     "bup": "^4.1.6",
@@ -54,7 +53,8 @@
     "jest-styled-components": "^4.11.0-0",
     "prettier": "^1.10.2",
     "react": "^16.2.0",
-    "react-test-renderer": "^16.2.0"
+    "react-test-renderer": "^16.2.0",
+    "styled-components": "3.1.4"
   },
   "lint-staged": {
     "**.{js,md}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4333,9 +4333,9 @@ styled-components@3.1.4:
     stylis-rule-sheet "^0.0.7"
     supports-color "^3.2.3"
 
-styled-is@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/styled-is/-/styled-is-1.1.2.tgz#f23a43249ba52ac9136c166aac1da30a5711593e"
+styled-is@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/styled-is/-/styled-is-1.1.5.tgz#acd8ad180217abea036e4f2cc58593899871f02a"
 
 stylis-rule-sheet@^0.0.7:
   version "0.0.7"


### PR DESCRIPTION
Upgrading `styled-is` mainly for https://github.com/yldio/styled-is/pull/16.

This PR is a straight upgrade to the latest version, just like it was doing before. However, instead of locking it to a specific version, maybe it's better loosen the dep to "1.x" instead?
